### PR TITLE
feat(aws-java-sdk): use AWS credentials chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ wish to access it.
 ### Pre-requisites
 - Java 11
 - Maven 3.6
-- Docker Engine (if you wish to run locally)
+- Docker Engine (if you wish to run the service locally)
+- AWS credentials (if you wish to run the service locally)
 
 To run just tests, type `mvn test`. This will also run the integration tests (which use an in-memory H2 database).
 
@@ -39,12 +40,10 @@ the hyperlinks from the main page work. However, you can open each individual HT
     
 ### Running locally
 
-To run the app locally, first set your AWS access key and secret access key in app.conf (in an AWS deployment, we would use IAM roles):
+To run the app locally, first set your AWS access key and secret access key in a file in the root of your repo called `.env` (in an AWS deployment, we would use IAM roles):
 ``` 
-      aws = {
-        access_key_id = "ENTER_ACCESS_KEY_HERE"
-        secret_access_key = "ENTER_SECRET_HERE"
-      }
+AWS_ACCESS_KEY_ID=<enter-your-access-key>
+AWS_SECRET_ACCESS_KEY=<enter-your-secret-access-key>
 ```
 
 run:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,3 +28,5 @@ services:
     environment:
       DB_URL: jdbc:postgresql://db:5432/aws_api
       DB_PASSWORD: BurakCr3shP1neapple!
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}

--- a/src/main/resources/app.conf
+++ b/src/main/resources/app.conf
@@ -14,10 +14,6 @@ webreq = {
 }
 
 aws = {
-  access_key_id = "ENTER_ACCESS_KEY_HERE"
-  access_key_id = ${?AWS_ACCESS_KEY_ID}
-  secret_access_key = "ENTER_SECRET_HERE"
-  secret_access_key = ${?AWS_SECRET_ACCESS_KEY}
   wait_time_sec = 10
 }
 

--- a/src/main/scala/info/siddhuw/ScalatraBootstrap.scala
+++ b/src/main/scala/info/siddhuw/ScalatraBootstrap.scala
@@ -41,8 +41,7 @@ class ScalatraBootstrap extends LifeCycle with PrimitiveTypeMode {
 
     implicit val awsService = new AWSService
 
-    val awsCreds = new BasicAWSCredentials(conf.getString("aws.access_key_id"), conf.getString("aws.secret_access_key"))
-    implicit val awsEc2Service = new AWSEC2Service(new AmazonEC2Client(awsCreds))
+    implicit val awsEc2Service = new AWSEC2Service(new AmazonEC2Client())
 
     context.mount(new AuthUserController, "/auth/*")
     context.mount(new AWSController, "/api/aws/*")

--- a/src/main/scala/info/siddhuw/services/AWSEC2Service.scala
+++ b/src/main/scala/info/siddhuw/services/AWSEC2Service.scala
@@ -28,7 +28,6 @@ class AWSEC2Service(val ec2: AmazonEC2)(implicit ec: ExecutionContext) {
    * @return the list of AWS EC2 instances of type EC2Instance
    */
   def list(region: String, activeOnly: Boolean = true): List[EC2Instance] = {
-    val filter = new Filter()
     val instanceResult = describeInstances(region, activeOnly)
 
     instanceResult.getReservations.asScala.flatMap {


### PR DESCRIPTION
Stop reading AWS creds from app.conf and use the AWS default Credential Provider Chain
(https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html). This sets things up
nicely for an AWS ECS/Fargate deployment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siddhuwarrier/aws-api/8)
<!-- Reviewable:end -->
