### PR TITLE
feat(rate-limiting): limit rate at which AWS API endpoints can be hit

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ wish to access it.
 
 | Endpoint        | Params | Response  |
 | ------------- |:-------------:| -----:|
-| POST /auth      | BODY {"username": username, "password": password} | 200 with JSON containing JWT token, 401 UNAUTHORIZED if username and/or password are invalid |
+| POST /auth      | BODY {"username": username, "password": password} | 200 with JSON containing JWT token, 401 UNAUTHORIZED if username and/or password are invalid) |
 | GET /versions      |  | 200 with JSON containing git commit hash of latest commit |
 | GET /health      |  | 200 with JSON containing git commit hash of latest commit if running |
-| GET /api/aws/regions      | AUTHORIZATION header set with bearer token returned in  (Bearer `JWT token`)      |   200 with JSON of list of regions, 401 UNAUTHORIZED  |
-| GET /api/aws/ec2/instances | AUTHORIZATION header set with bearer token returned in  (Bearer `JWT token`)     |    200 with JSON of list of instances, 401 UNAUTHORIZED, 500 INTERNAL SERVER ERROR (if AWS credentials invalid), 503 SERVICE UNAVAILABLE (if AWS inaccessible) |
+| GET /api/aws/regions      | AUTHORIZATION header set with bearer token returned in  (Bearer `JWT token`)      |   200 with JSON of list of regions, 401 UNAUTHORIZED, 429 TOO MANY REQUESTS if you exceed the rate limit (managed using a token bucket algorithm  |
+| GET /api/aws/ec2/instances | AUTHORIZATION header set with bearer token returned in  (Bearer `JWT token`)     |    200 with JSON of list of instances, 401 UNAUTHORIZED, 429 TOO MANY REQUESTS if you exceed the rate limit (managed using a token bucket algorithm, 500 INTERNAL SERVER ERROR (if AWS credentials invalid), 503 SERVICE UNAVAILABLE (if AWS inaccessible) |
 
 ## AWS deployment
 

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
         <json4s.version>3.6.10</json4s.version>
         <logstash.version>4.3</logstash.version>
         <slf4j.version>1.7.7</slf4j.version>
+        <bucket4j.version>6.0.1</bucket4j.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
@@ -201,6 +202,13 @@
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk</artifactId>
             <version>${aws-java-sdk.version}</version>
+        </dependency>
+
+        <!-- Rate limiting -->
+        <dependency>
+            <groupId>com.github.vladimir-bukhtoyarov</groupId>
+            <artifactId>bucket4j-core</artifactId>
+            <version>${bucket4j.version}</version>
         </dependency>
     </dependencies>
 

--- a/src/main/resources/app.conf
+++ b/src/main/resources/app.conf
@@ -17,6 +17,10 @@ aws = {
   wait_time_sec = 10
 }
 
+rate_limit {
+    bucket_capacity = 100
+}
+
 # Database config
 db = {
   url = "jdbc:postgresql://localhost:5432/aws_api"

--- a/src/main/scala/info/siddhuw/ScalatraBootstrap.scala
+++ b/src/main/scala/info/siddhuw/ScalatraBootstrap.scala
@@ -10,7 +10,7 @@ import info.siddhuw.controllers.api.aws.AWSController
 import info.siddhuw.controllers.api.aws.ec2.AWSEC2Controller
 import info.siddhuw.metrics.ServiceHealthCheck
 import info.siddhuw.models.daos.DBUserDAO
-import info.siddhuw.services.{ AWSEC2Service, AWSService, JWTTokenService, VersionsService }
+import info.siddhuw.services.{ AWSEC2Service, AWSService, JWTTokenService, ThrottlingService, VersionsService }
 import org.scalatra.LifeCycle
 import org.scalatra.metrics.MetricsBootstrap
 import org.scalatra.metrics.MetricsSupportExtensions.metricsSupportExtensions
@@ -45,6 +45,7 @@ class ScalatraBootstrap extends LifeCycle with PrimitiveTypeMode with MetricsBoo
     implicit val awsService = new AWSService
     implicit val awsEc2Service = new AWSEC2Service(new AmazonEC2Client())
     implicit val versionsService = new VersionsService
+    implicit val throttlingService = new ThrottlingService
 
     healthCheckRegistry.register("service", new ServiceHealthCheck)
 

--- a/src/main/scala/info/siddhuw/controllers/JsonController.scala
+++ b/src/main/scala/info/siddhuw/controllers/JsonController.scala
@@ -2,6 +2,7 @@ package info.siddhuw.controllers
 
 import org.scalatra.ScalatraServlet
 import org.scalatra.json.JacksonJsonSupport
+import org.slf4j.{ Logger, LoggerFactory }
 import org.squeryl.PrimitiveTypeMode
 
 /**
@@ -11,4 +12,8 @@ import org.squeryl.PrimitiveTypeMode
 trait JsonController extends ScalatraServlet
     with PrimitiveTypeMode
     with JacksonJsonSupport {
+  private val logger: Logger = LoggerFactory.getLogger(classOf[JsonController])
+  before() {
+    contentType = formats("json")
+  }
 }

--- a/src/main/scala/info/siddhuw/controllers/api/BaseAPIController.scala
+++ b/src/main/scala/info/siddhuw/controllers/api/BaseAPIController.scala
@@ -2,8 +2,16 @@ package info.siddhuw.controllers.api
 
 import info.siddhuw.auth.APIAuthenticationSupport
 import info.siddhuw.controllers.JsonController
+import info.siddhuw.controllers.api.BaseAPIController.{ TooManyRequestsMsg, UnauthorizedErrMsg }
+import info.siddhuw.services.ThrottlingService
+import net.logstash.logback.marker.Markers.appendEntries
 import org.json4s.{ DefaultFormats, Formats }
-import org.scalatra.CorsSupport
+import org.scalatra.{ CorsSupport, TooManyRequests, Unauthorized }
+import org.slf4j.LoggerFactory
+
+import scala.concurrent.duration._
+import scala.jdk.CollectionConverters._
+import scala.language.postfixOps
 
 /**
  * @author Siddhu Warrier
@@ -12,13 +20,38 @@ import org.scalatra.CorsSupport
 trait BaseAPIController extends JsonController
     with APIAuthenticationSupport
     with CorsSupport {
+  private val logger = LoggerFactory.getLogger(classOf[BaseAPIController])
+
+  implicit val throttlingService: ThrottlingService
+
   override protected implicit def jsonFormats: Formats = DefaultFormats
 
+  val logData = Map("endpoint" -> "ANY authenticated endpoint")
   before() {
     contentType = formats("json")
+    authenticate() match {
+      case Some(user) ⇒
+        throttlingService.consumeToken(user) match {
+          case Right(retryAfter: FiniteDuration) ⇒
+            logger.error(appendEntries(logData.asJava), s"Failed: $TooManyRequestsMsg")
+            halt(
+              TooManyRequests("msg" -> TooManyRequestsMsg,
+                headers = Map("X-RateLimit-Remaining" -> retryAfter.toMillis.toString)))
+          case _ ⇒
+            logger.debug(appendEntries(logData.asJava), "Throttling not required")
+        }
+      case None ⇒
+        logger.error(appendEntries(logData.asJava), s"Failed: $UnauthorizedErrMsg")
+        halt(Unauthorized("msg" -> UnauthorizedErrMsg))
+    }
   }
 
   options("/*") {
     response.setHeader("Access-Control-Allow-Headers", request.getHeader("Access-Control-Request-Headers"))
   }
+}
+
+object BaseAPIController {
+  val UnauthorizedErrMsg = "You need to be logged in to view this endpoint"
+  val TooManyRequestsMsg = "Too many requests"
 }

--- a/src/main/scala/info/siddhuw/controllers/api/aws/AWSController.scala
+++ b/src/main/scala/info/siddhuw/controllers/api/aws/AWSController.scala
@@ -1,9 +1,9 @@
 package info.siddhuw.controllers.api.aws
 
 import info.siddhuw.controllers.api.BaseAPIController
-import info.siddhuw.controllers.api.aws.AWSController._
+import info.siddhuw.controllers.api.BaseAPIController._
 import info.siddhuw.models.daos.DBUserDAO
-import info.siddhuw.services.AWSService
+import info.siddhuw.services.{ AWSService, ThrottlingService }
 import net.logstash.logback.marker.Markers._
 import org.scalatra.Unauthorized
 import org.slf4j.LoggerFactory
@@ -14,7 +14,7 @@ import scala.jdk.CollectionConverters._
  * @author Siddhu Warrier
  */
 
-class AWSController(implicit val awsService: AWSService, implicit val userDao: DBUserDAO) extends BaseAPIController {
+class AWSController(implicit val awsService: AWSService, implicit val userDao: DBUserDAO, implicit val throttlingService: ThrottlingService) extends BaseAPIController {
   val logger = LoggerFactory.getLogger(classOf[AWSController])
 
   get("/regions") {
@@ -27,12 +27,8 @@ class AWSController(implicit val awsService: AWSService, implicit val userDao: D
 
         regions
       case None ⇒
-        logger.error(appendEntries(logData.asJava), s"Failed: $UnauthorizedMsg")
-        halt(Unauthorized("msg" -> UnauthorizedMsg))
+        logger.error(appendEntries(logData.asJava), s"Failed: $UnauthorizedErrMsg")
+        halt(Unauthorized("msg" -> UnauthorizedErrMsg))
     }
   }
-}
-
-object AWSController {
-  val UnauthorizedMsg = "You need to be logged in to view this endpoint"
 }

--- a/src/main/scala/info/siddhuw/controllers/api/aws/ec2/AWSEC2Controller.scala
+++ b/src/main/scala/info/siddhuw/controllers/api/aws/ec2/AWSEC2Controller.scala
@@ -6,7 +6,7 @@ import info.siddhuw.controllers.JsonController
 import info.siddhuw.controllers.api.BaseAPIController
 import info.siddhuw.controllers.api.aws.ec2.AWSEC2Controller._
 import info.siddhuw.models.daos.DBUserDAO
-import info.siddhuw.services.AWSEC2Service
+import info.siddhuw.services.{ AWSEC2Service, ThrottlingService }
 import net.logstash.logback.marker.Markers._
 import org.json4s.{ DefaultFormats, Formats }
 import org.scalatra._
@@ -19,40 +19,33 @@ import scala.jdk.CollectionConverters._
  * @author Siddhu Warrier
  */
 
-class AWSEC2Controller(implicit val awsEc2Service: AWSEC2Service, implicit val userDao: DBUserDAO) extends BaseAPIController {
+class AWSEC2Controller(implicit val awsEc2Service: AWSEC2Service, implicit val userDao: DBUserDAO, implicit val throttlingService: ThrottlingService) extends BaseAPIController {
   val logger: Logger = LoggerFactory.getLogger(classOf[AWSEC2Controller])
 
   get("/instances") {
     val logData = Map("endpoint" -> "GET /instances")
 
-    authenticate() match {
-      case Some(_) ⇒
-        val region = params.getOrElse("region", halt(BadRequest("msg" -> RegionParamMissingErrMsg)))
+    val region = params.getOrElse("region", halt(BadRequest("msg" -> RegionParamMissingErrMsg)))
 
-        try {
-          logger.info(appendEntries((logData + ("Action" -> "List instances")).asJava), "Start")
-          val instances = awsEc2Service.list(region, activeOnly = true)
-          Option(instances).getOrElse(halt(InternalServerError("msg" -> InternalServerErrMsg)))
-          logger.info(appendEntries((logData + ("Action" -> "List instances")).asJava), "Done")
+    try {
+      logger.info(appendEntries((logData + ("Action" -> "List instances")).asJava), "Start")
+      val instances = awsEc2Service.list(region, activeOnly = true)
+      Option(instances).getOrElse(halt(InternalServerError("msg" -> InternalServerErrMsg)))
+      logger.info(appendEntries((logData + ("Action" -> "List instances")).asJava), "Done")
 
-          instances
-        } catch {
-          case e: AmazonServiceException if e.getStatusCode == SC_UNAUTHORIZED ⇒
-            logger.error(appendEntries((logData + ("Action" -> "List instances")).asJava), "Failed: ", e)
-            halt(InternalServerError("msg" -> AWSCredentialsInvalidErrMsg))
+      instances
+    } catch {
+      case e: AmazonServiceException if e.getStatusCode == SC_UNAUTHORIZED ⇒
+        logger.error(appendEntries((logData + ("Action" -> "List instances")).asJava), "Failed: ", e)
+        halt(InternalServerError("msg" -> AWSCredentialsInvalidErrMsg))
 
-          case e: AmazonClientException ⇒
-            logger.error(appendEntries((logData + ("Action" -> "List instances")).asJava), "Failed: ", e)
-            halt(ServiceUnavailable("msg" -> UnableToReadFromEC2ErrMsg))
+      case e: AmazonClientException ⇒
+        logger.error(appendEntries((logData + ("Action" -> "List instances")).asJava), "Failed: ", e)
+        halt(ServiceUnavailable("msg" -> UnableToReadFromEC2ErrMsg))
 
-          case e: IllegalArgumentException ⇒
-            logger.error(appendEntries((logData + ("Action" -> "List instances")).asJava), "Failed: ", e)
-            halt(BadRequest("msg" -> RegionParamInvalidErrMsg))
-        }
-
-      case None ⇒
-        logger.error(appendEntries(logData.asJava), s"Failed: $UnauthorizedErrMsg")
-        halt(Unauthorized("msg" -> UnauthorizedErrMsg))
+      case e: IllegalArgumentException ⇒
+        logger.error(appendEntries((logData + ("Action" -> "List instances")).asJava), "Failed: ", e)
+        halt(BadRequest("msg" -> RegionParamInvalidErrMsg))
     }
   }
 }
@@ -63,5 +56,4 @@ object AWSEC2Controller {
   val UnableToReadFromEC2ErrMsg = "Unable to read from EC2. Please try again later."
   val AWSCredentialsInvalidErrMsg = "The AWS credentials configured on the server are invalid. Please contact customer support."
   val InternalServerErrMsg = "Internal Server Error. Please contact customer support."
-  val UnauthorizedErrMsg = "You need to be logged in to view this endpoint"
 }

--- a/src/main/scala/info/siddhuw/services/ThrottlingService.scala
+++ b/src/main/scala/info/siddhuw/services/ThrottlingService.scala
@@ -1,0 +1,43 @@
+package info.siddhuw.services
+
+import com.typesafe.config.ConfigFactory
+import info.siddhuw.models.DBUser
+import info.siddhuw.services.ThrottlingService.DEFAULT_BANDWIDTH_LIMIT
+import io.github.bucket4j.{ Bandwidth, Bucket, Bucket4j }
+import org.slf4j.LoggerFactory
+
+import java.util.concurrent.ConcurrentHashMap
+import scala.collection._
+import scala.concurrent.duration._
+import scala.jdk.CollectionConverters._
+import scala.jdk.DurationConverters._
+import scala.language.postfixOps
+
+class ThrottlingService {
+  // throttling cache represented as a concurrent map in memory. TODO replace with Redis
+  val throttlingCache: concurrent.Map[String, Bucket] = new ConcurrentHashMap[String, Bucket]().asScala
+
+  def consumeToken(user: DBUser): Either[Unit, FiniteDuration] = {
+    val bucket = throttlingCache.getOrElseUpdate(user.username, initBucket())
+    val probe = bucket.tryConsumeAndReturnRemaining(1)
+    if (probe.isConsumed) {
+      // successful; does not matter when it refills
+      return Left()
+    }
+
+    Right(probe.getNanosToWaitForRefill nanos)
+  }
+
+  private def initBucket(): Bucket = {
+    Bucket4j.builder()
+      .addLimit(DEFAULT_BANDWIDTH_LIMIT)
+      .build()
+  }
+}
+
+object ThrottlingService {
+  // the default bandwidth limit is set to 100 requests for a minute.
+  val DEFAULT_BANDWIDTH_LIMIT: Bandwidth = Bandwidth.simple(
+    ConfigFactory load "app" getInt "rate_limit.bucket_capacity",
+    (1 minute) toJava)
+}

--- a/src/test/resources/app.conf
+++ b/src/test/resources/app.conf
@@ -14,3 +14,7 @@ aws {
 webreq = {
   wait_time_sec = 5
 }
+
+rate_limit {
+    bucket_capacity = 10
+}

--- a/src/test/scala/info/siddhuw/controllers/api/aws/AWSControllerRegionSpec.scala
+++ b/src/test/scala/info/siddhuw/controllers/api/aws/AWSControllerRegionSpec.scala
@@ -2,19 +2,27 @@ package info.siddhuw.controllers.api.aws
 
 import com.google.common.base.CharMatcher
 import com.google.common.net.HttpHeaders._
+import info.siddhuw.controllers.api.BaseAPIController
 import info.siddhuw.models.APISchema._
 import info.siddhuw.models.daos.DBUserDAO
 import info.siddhuw.models.{ AWSRegion, DBUser }
-import info.siddhuw.services.{ AWSService, JWTTokenService }
+import info.siddhuw.services.{ AWSService, JWTTokenService, ThrottlingService }
 import info.siddhuw.utils.DatabaseSupport
 import info.siddhuw.utils.crypto.PasswordHasher
 import org.apache.commons.httpclient.HttpStatus._
 import org.json4s.jackson.JsonMethods._
 import org.json4s.{ DefaultFormats, Formats }
+import org.mockito.Mockito.when
 import org.scalatest._
 import org.scalatest.featurespec.AnyFeatureSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatra.test.scalatest.ScalatraSuite
+import org.mockito.Matchers.any
+import org.mockito.Mockito
+
+import scala.language.postfixOps
+import scala.concurrent.duration._
 
 /**
  * @author Siddhu Warrier
@@ -23,11 +31,14 @@ import org.scalatra.test.scalatest.ScalatraSuite
 class AWSControllerRegionSpec extends AnyFeatureSpec
     with GivenWhenThen
     with BeforeAndAfterAll
+    with BeforeAndAfter
     with DatabaseSupport
     with ScalatraSuite
+    with MockitoSugar
     with Matchers {
-  implicit val awsService = new AWSService //AWS Service does not currently connect to the internet; so no need to mock
-  implicit val userDao = new DBUserDAO
+  implicit val awsService: AWSService = new AWSService //AWS Service does not currently connect to the internet; so no need to mock
+  implicit val userDao: DBUserDAO = new DBUserDAO
+  implicit val mockThrottlingService: ThrottlingService = mock[ThrottlingService]
   addServlet(new AWSController, "/api/aws/*")
 
   implicit def jsonFormats: Formats = DefaultFormats
@@ -42,11 +53,19 @@ class AWSControllerRegionSpec extends AnyFeatureSpec
     super.afterAll()
   }
 
+  before {
+    when(mockThrottlingService.consumeToken(any[DBUser])).thenAnswer(_ ⇒ Left())
+  }
+
+  after {
+    Mockito.reset(mockThrottlingService)
+  }
+
   Feature("Retrieve the list of AWS regions") {
     Scenario("Retrieve the full list of regions, except for China and GovCloud") {
       Given("I am logged in")
       loggedIn {
-        (dbUser: DBUser, token: String) ⇒
+        (_: DBUser, token: String) ⇒
 
           When("I retrieve the list of regions")
           get("/api/aws/regions", headers = Map(AUTHORIZATION -> ("Bearer " + token))) {
@@ -56,9 +75,30 @@ class AWSControllerRegionSpec extends AnyFeatureSpec
 
             And("I should receive a JSON with all of the regions except China and GovCloud")
             val actualRegions = parse(body).extract[List[AWSRegion]]
-            val expectedRegions = awsService.regions(excludeChina = true, excludeGov = true)
+            val expectedRegions = awsService.regions()
 
             actualRegions should equal(expectedRegions)
+          }
+      }
+    }
+
+    Scenario("Fail to retrieve full list if requests exceeded") {
+      Given("I am logged in")
+      loggedIn {
+        (dbUser: DBUser, token: String) ⇒
+
+          And("I have exceeded the rate limit allowed by the API")
+          when(mockThrottlingService.consumeToken(dbUser)).thenReturn(Right(30 seconds))
+
+          When("I retrieve the list of regions")
+          get("/api/aws/regions", headers = Map(AUTHORIZATION -> ("Bearer " + token))) {
+
+            Then("I should receive a status code of 429")
+            status should equal(429)
+
+            And("I should receive a JSON with all of the regions except China and GovCloud")
+            val errMsg = compact(render(parse(body) \ "msg"))
+            CharMatcher.is('\"').trimFrom(errMsg) should equal(BaseAPIController.TooManyRequestsMsg)
           }
       }
     }
@@ -72,7 +112,7 @@ class AWSControllerRegionSpec extends AnyFeatureSpec
 
         And("I should receive an error message")
         val errMsg = compact(render(parse(body) \ "msg"))
-        CharMatcher.is('\"').trimFrom(errMsg) should equal(AWSController.UnauthorizedMsg)
+        CharMatcher.is('\"').trimFrom(errMsg) should equal(BaseAPIController.UnauthorizedErrMsg)
       }
     }
   }

--- a/src/test/scala/info/siddhuw/services/ThrottlingServiceSpec.scala
+++ b/src/test/scala/info/siddhuw/services/ThrottlingServiceSpec.scala
@@ -1,0 +1,27 @@
+package info.siddhuw.services
+
+import com.typesafe.config.ConfigFactory
+import info.siddhuw.utils.builders.DBUserBuilder
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ThrottlingServiceSpec extends AnyFlatSpec with Matchers {
+  "The Throttle Service" should "return nothing if there are tokens to consume in the bucket" in {
+    val throttleService = new ThrottlingService
+    val user = DBUserBuilder.build("burak-crush-kim-jong-un")
+    throttleService.consumeToken(user) match {
+      case Right(_) ⇒ fail("Should not have returned a duration which indicates the amount of time left before I can query again")
+      case _ ⇒ // nothing to do, this is what we expect; it returns a Unit
+    }
+  }
+
+  it should "return the amount of time required to wait if the bucket is empty" in {
+    val throttleService = new ThrottlingService
+    val user = DBUserBuilder.build("burak-crush-kim-jong-un")
+    (1 to ConfigFactory.load("app").getInt("rate_limit.bucket_capacity")) foreach (_ ⇒ throttleService.consumeToken(user))
+    throttleService.consumeToken(user) match {
+      case Left(_) ⇒ fail("Should have refused service coz no tokens left")
+      case Right(duration) ⇒ duration should not be (null)
+    }
+  }
+}


### PR DESCRIPTION
This commit adds the Bucket4J token bucket implementation to limit the number of API calls that can
be made. By default, in staging, we limit requests to 100/minute.

If the rate limit is exceeded, the user gets a HTTP 429 TOO_MANY_REQUESTS response, with the time to wait in ms before the next request set in the `X-RateLimit-Remaining` header (see https://tools.ietf.org/id/draft-polli-ratelimit-headers-00.html).

For example:

```
< HTTP/1.1 429
< Set-Cookie: JSESSIONID=B37ED00E3E206A09074CCBB1C359F90F; Path=/; HttpOnly
< X-RateLimit-Remaining: 192
< Content-Type: application/json;charset=UTF-8
< Content-Length: 27
< Date: Mon, 01 Feb 2021 00:37:29 GMT
<
{ [27 bytes data]
100    27  100    27    0     0    710      0 --:--:-- --:--:-- --:--:--   710
* Connection #0 to host localhost left intact
* Closing connection 0
{
  "msg": "Too many requests"
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/siddhuwarrier/aws-api/18)
<!-- Reviewable:end -->
